### PR TITLE
[WFCOM-19] Upgrade jboss-logging-tools to version 2.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-tools>2.1.0.Beta1</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCOM-19