### PR TITLE
Allow empty default value

### DIFF
--- a/src/main/java/org/wildfly/common/expression/Expression.java
+++ b/src/main/java/org/wildfly/common/expression/Expression.java
@@ -544,7 +544,8 @@ public final class Expression {
                     } else if (endOnBrace) {
                         // TP 30
                         itr.prev(); // back up to point at } again
-                        if (idx > start) {
+                        // TP 46 // allow an empty default value
+                        if (idx >= start) {
                             list.add(new LiteralNode(itr.getStr(), start, idx));
                         }
                         return Node.fromList(list);

--- a/src/test/java/org/wildfly/common/expression/ExpressionTestCase.java
+++ b/src/test/java/org/wildfly/common/expression/ExpressionTestCase.java
@@ -19,6 +19,7 @@
 package org.wildfly.common.expression;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -536,6 +537,16 @@ public class ExpressionTestCase {
         final Expression expression = Expression.compile("W:\\\\workspace\\\\some-path\\\\xxxxyyyy", Expression.Flag.ESCAPES);
         assertEquals("W:\\workspace\\some-path\\xxxxyyyy", expression.evaluate((c, b) -> {
             fail("unexpected expansion");
+        }));
+    }
+
+    @Test
+    public void testPoint46() throws Exception {
+        // an empty default value is valid
+        final Expression expression = Expression.compile("${foo.bar:}");
+        assertEquals("Should expand to empty string", "", expression.evaluate((c, b) -> {
+            assertTrue(c.hasDefault());
+            assertEquals("", c.getExpandedDefault());
         }));
     }
 }


### PR DESCRIPTION
`${foo.bar:}` is now an expression which has a default empty value
(athe `""` String).
Previously this expression would have a `NULL` default
value and `context.hasDefault()` would return `false`.

Add ExpressionTestCase#testPoint46 to test this use case.