### PR TITLE
Add CompositeIterable/Iterator.

### DIFF
--- a/src/main/java/org/wildfly/common/iteration/CompositeIterable.java
+++ b/src/main/java/org/wildfly/common/iteration/CompositeIterable.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.iteration;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * Used for iterating over an series of iterables, thus avoiding the need to allocate/populate a new list containing all elements.
+ * More efficient than the alternative when the number of iterables is arbitrary and small relative to the size of each iterable.
+ * @author Paul Ferraro
+ */
+public class CompositeIterable<T> implements Iterable<T> {
+
+    private final List<? extends Iterable<? extends T>> iterables;
+
+    /**
+     * Constructs a new composite iterable.
+     * @param iterables a series of iterables
+     */
+    @SafeVarargs
+    public CompositeIterable(Iterable<? extends T>... iterables) {
+        this(Arrays.asList(iterables));
+    }
+
+    /**
+     * Constructs a new composite iterable.
+     * @param iterables a series of iterables
+     */
+    public CompositeIterable(List<? extends Iterable<? extends T>> iterables) {
+        this.iterables = iterables;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        List<Iterator<? extends T>> iterators = new ArrayList<>(this.iterables.size());
+        for (Iterable<? extends T> elements : this.iterables) {
+            iterators.add(elements.iterator());
+        }
+        return new CompositeIterator<>(iterators);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        for (Iterable<? extends T> elements : this.iterables) {
+            for (T element : elements) {
+                result = 31 * result + ((element != null) ? element.hashCode() : 0);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof Iterable)) return false;
+        @SuppressWarnings("unchecked")
+        Iterator<Object> otherElements = ((Iterable<Object>) object).iterator();
+        for (Iterable<? extends T> iterable : this.iterables) {
+            Iterator<? extends T> elements = iterable.iterator();
+            while (elements.hasNext() && otherElements.hasNext()) {
+                elements.next().equals(otherElements.next());
+            }
+            if (elements.hasNext()) return false;
+        }
+        return !otherElements.hasNext();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append('[');
+        Iterator<? extends Iterable<? extends T>> iterables = this.iterables.iterator();
+        while (iterables.hasNext()) {
+            Iterator<? extends T> elements = iterables.next().iterator();
+            while (elements.hasNext()) {
+                if (builder.length() > 1) {
+                    builder.append(',').append(' ');
+                }
+                builder.append(elements.next());
+            }
+        }
+        return builder.append(']').toString();
+    }
+}

--- a/src/main/java/org/wildfly/common/iteration/CompositeIterator.java
+++ b/src/main/java/org/wildfly/common/iteration/CompositeIterator.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.iteration;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+
+/**
+ * Iterator that iterates over a series of iterators.
+ * @author Paul Ferraro
+ */
+public class CompositeIterator<E> implements Iterator<E> {
+
+    private final Iterable<? extends Iterator<? extends E>> iterators;
+    private Iterator<? extends E> lastIterator;
+
+    /**
+     * Constructs a new composite iterator.
+     * @param iterables a series of iterators
+     */
+    @SafeVarargs
+    public CompositeIterator(Iterator<? extends E>... iterators) {
+        this(Arrays.asList(iterators));
+    }
+
+    /**
+     * Constructs a new composite iterator.
+     * @param iterables a series of iterators
+     */
+    public CompositeIterator(Iterable<? extends Iterator<? extends E>> iterators) {
+        this.iterators = iterators;
+    }
+
+    @Override
+    public boolean hasNext() {
+        for (Iterator<? extends E> iterator : this.iterators) {
+            if (iterator.hasNext()) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public E next() {
+        for (Iterator<? extends E> iterator : this.iterators) {
+            if (iterator.hasNext()) {
+                this.lastIterator = iterator;
+                return iterator.next();
+            }
+        }
+        throw new NoSuchElementException();
+    }
+
+    @Override
+    public void remove() {
+        Iterator<? extends E> iterator = this.lastIterator;
+        if (iterator == null) {
+            throw new IllegalStateException();
+        }
+        iterator.remove();
+    }
+
+    @Override
+    public void forEachRemaining(Consumer<? super E> action) {
+        for (Iterator<? extends E> iterator : this.iterators) {
+            while (iterator.hasNext()) {
+                action.accept(iterator.next());
+            }
+        }
+    }
+}

--- a/src/test/java/org/wildfly/common/iteration/CompositeIterableTestCase.java
+++ b/src/test/java/org/wildfly/common/iteration/CompositeIterableTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.iteration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link CompositeIterable}.
+ * @author Paul Ferraro
+ */
+public class CompositeIterableTestCase {
+
+    @Test
+    public void test() {
+        List<Integer> expected = IntStream.range(0, 10).mapToObj(Integer::valueOf).collect(Collectors.toList());
+
+        test(expected, new CompositeIterable<>(new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4)), Arrays.asList(5, 6, 7, 8, 9)));
+        test(expected, new CompositeIterable<>(new ArrayList<>(Arrays.asList(0, 1)), Arrays.asList(2, 3), Arrays.asList(4, 5), Arrays.asList(6, 7), Arrays.asList(8, 9)));
+        test(expected, new CompositeIterable<>(Collections.emptyList(), new ArrayList<>(expected), Collections.emptyList()));
+    }
+
+    @Test
+    public void testRemove() {
+        
+    }
+
+    static void test(Iterable<Integer> expected, Iterable<Integer> subject) {
+        Assert.assertEquals(expected.hashCode(), subject.hashCode());
+        Assert.assertEquals(expected.toString(), subject.toString());
+
+        Iterator<Integer> subjectIterator = subject.iterator();
+        Iterator<Integer> expectedIterator = expected.iterator();
+        while (expectedIterator.hasNext()) {
+            Assert.assertTrue(subjectIterator.hasNext());
+            Assert.assertEquals(expectedIterator.next(), subjectIterator.next());
+        }
+        Assert.assertFalse(subjectIterator.hasNext());
+    }
+}

--- a/src/test/java/org/wildfly/common/iteration/CompositeIteratorTestCase.java
+++ b/src/test/java/org/wildfly/common/iteration/CompositeIteratorTestCase.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.iteration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link CompositeIterator}.
+ * @author Paul Ferraro
+ */
+public class CompositeIteratorTestCase {
+
+    @Test
+    public void remove() {
+        List<Integer> list = new ArrayList<>(IntStream.range(0, 10).mapToObj(Integer::valueOf).collect(Collectors.toList()));
+        Iterator<Integer> iterator = new CompositeIterator<>(Collections.<Integer>emptyList().iterator(), list.iterator(), Collections.<Integer>emptyList().iterator());
+
+        try {
+            iterator.remove();
+            Assert.fail("remove() should fail before first call to next()");
+        } catch (IllegalStateException e) {
+            // Expected
+        }
+
+        IntStream.range(0, 10).forEach(i -> {
+            Assert.assertTrue(iterator.hasNext());
+            Assert.assertEquals(i, iterator.next().intValue());
+            iterator.remove();
+        });
+        Assert.assertFalse(iterator.hasNext());
+
+        try {
+            iterator.next();
+            Assert.fail("next() should fail when hasNext() = false");
+        } catch (NoSuchElementException e) {
+            // Expected
+        }
+
+        Assert.assertTrue(list.isEmpty());
+    }
+
+
+    @Test
+    public void forEachRemaining() {
+        List<Integer> list1 = IntStream.range(0, 5).mapToObj(Integer::valueOf).collect(Collectors.toList());
+        List<Integer> list2 = IntStream.range(5, 10).mapToObj(Integer::valueOf).collect(Collectors.toList());
+        Iterator<Integer> iterator = new CompositeIterator<>(Collections.<Integer>emptyList().iterator(), list1.iterator(), list2.iterator(), Collections.<Integer>emptyList().iterator());
+
+        Assert.assertTrue(iterator.hasNext());
+        // Skip 0
+        iterator.next();
+        Assert.assertTrue(iterator.hasNext());
+
+        int expected = IntStream.range(1, 10).reduce(1, Math::multiplyExact);
+        AtomicInteger result = new AtomicInteger(1);
+        iterator.forEachRemaining(value -> result.accumulateAndGet(value, Math::multiplyExact));
+        Assert.assertEquals(expected, result.get());
+
+        // Iterator should be drained
+        Assert.assertFalse(iterator.hasNext());
+
+        try {
+            iterator.next();
+            Assert.fail("next() should fail when hasNext() = false");
+        } catch (NoSuchElementException e) {
+            // Expected
+        }
+    }
+}


### PR DESCRIPTION
There are many places in WildFly where ArrayLists are allocated and populated from an arbitrary number of child lists just for the purpose/convenience of iteration.
e.g.
```java
List<T> list1 = ...;
List<T> list2 = ...;
List<T> list3 = ...;

List<T> list = new ArrayList(list1.size() + list2.size() + list3.size());
list.addAll(list1);
list.addAll(list2);
list.addAll(list3);
for (T element : list) {
   // Do something
}
```

CompositeIterable aims to reduce the memory footprint and performance of the above usage pattern with the same convenience where the number of child lists is arbitrary and small when compared to the size of the child lists.

e.g.
```java
List<T> list1 = ...;
List<T> list2 = ...;
List<T> list3 = ...;

for (T element : new CompositeIterable<>(list1, list2, list3)) {
   // Do something
}
```