### PR TITLE
Fix some javadoc generation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,12 +145,7 @@
                 <configuration>
                     <detectJavaApiLink>false</detectJavaApiLink>
                     <detectLinks>false</detectLinks>
-                    <doctitle><![CDATA[WildFly Common ]]>${project.version}</doctitle>
-                    <header><![CDATA[WildFly Common ]]>${project.version}</header>
-                    <footer><![CDATA[WildFly Common ]]>${project.version}</footer>
-                    <bottom><![CDATA[<i>Copyright &#169; 2018 JBoss, a division of Red Hat, Inc.</i>]]></bottom>
                     <doclint>none</doclint>
-                    <legacyMode>true</legacyMode>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This should fix https://issues.redhat.com/browse/WFCOM-67 or at least get us down to just warnings.